### PR TITLE
Dev 202111 cli nat

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include data *
+recursive-include exclude-cfg *

--- a/clear/main.py
+++ b/clear/main.py
@@ -9,6 +9,7 @@ from utilities_common import util_base
 from show.plugins.pbh import read_pbh_counters
 from config.plugins.pbh import serialize_pbh_counters
 from . import plugins
+from utilities_common.helper import get_exclude_cfg_list
 
 # This is from the aliases example:
 # https://github.com/pallets/click/blob/57c6f09611fc47ca80db0bd010f05998b3c0aa95/examples/aliases/aliases.py
@@ -113,6 +114,7 @@ def run_command(command, pager=False, return_output=False, return_exitstatus=Fal
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 
+exclude_cli_list = get_exclude_cfg_list()
 
 #
 # 'cli' group (root group) ###
@@ -430,10 +432,11 @@ def line(target, devicename):
     click.echo(output)
     sys.exit(exitstatus)
 
-#add nat commands ("clear nat statistics", "clear nat translations")
-from . import nat
-cli.add_command(nat.statistics)
-cli.add_command(nat.translations)
+if 'INCLUDE_NAT: n' not in exclude_cli_list:
+    #add nat commands ("clear nat statistics", "clear nat translations")
+    from . import nat
+    cli.add_command(nat.statistics)
+    cli.add_command(nat.translations)
 
 # 'pbh' group ("clear pbh ...")
 @cli.group(cls=AliasedGroup)

--- a/clear/main.py
+++ b/clear/main.py
@@ -10,7 +10,6 @@ from show.plugins.pbh import read_pbh_counters
 from config.plugins.pbh import serialize_pbh_counters
 from . import plugins
 
-
 # This is from the aliases example:
 # https://github.com/pallets/click/blob/57c6f09611fc47ca80db0bd010f05998b3c0aa95/examples/aliases/aliases.py
 class Config(object):
@@ -431,30 +430,10 @@ def line(target, devicename):
     click.echo(output)
     sys.exit(exitstatus)
 
-#
-# 'nat' group ("clear nat ...")
-#
-
-@cli.group(cls=AliasedGroup)
-def nat():
-    """Clear the nat info"""
-    pass
-
-# 'statistics' subcommand ("clear nat statistics")
-@nat.command()
-def statistics():
-    """ Clear all NAT statistics """
-
-    cmd = "natclear -s"
-    run_command(cmd)
-
-# 'translations' subcommand ("clear nat translations")
-@nat.command()
-def translations():
-    """ Clear all NAT translations """
-
-    cmd = "natclear -t"
-    run_command(cmd)
+#add nat commands ("clear nat statistics", "clear nat translations")
+from . import nat
+cli.add_command(nat.statistics)
+cli.add_command(nat.translations)
 
 # 'pbh' group ("clear pbh ...")
 @cli.group(cls=AliasedGroup)

--- a/clear/nat.py
+++ b/clear/nat.py
@@ -1,0 +1,27 @@
+import utilities_common.cli as clicommon
+from clear.main import run_command, AliasedGroup, cli
+
+#
+# 'nat' group ("clear nat ...")
+#
+
+@cli.group(cls=AliasedGroup)
+def nat():
+    """Clear the nat info"""
+    pass
+
+# 'statistics' subcommand ("clear nat statistics")
+@nat.command()
+def statistics():
+    """ Clear all NAT statistics """
+
+    cmd = "natclear -s"
+    run_command(cmd)
+
+# 'translations' subcommand ("clear nat translations")
+@nat.command()
+def translations():
+    """ Clear all NAT translations """
+
+    cmd = "natclear -t"
+    run_command(cmd)

--- a/config/main.py
+++ b/config/main.py
@@ -28,7 +28,7 @@ from utilities_common.intf_filter import parse_interface_in_filter
 from utilities_common import bgp_util
 import utilities_common.cli as clicommon
 from utilities_common.general import load_db_config
-from utilities_common.helper import get_port_pbh_binding, get_port_acl_binding
+from utilities_common.helper import get_port_pbh_binding, get_port_acl_binding, get_exclude_cfg_list
 
 from .utils import log
 
@@ -1079,6 +1079,7 @@ def config(ctx):
 
     ctx.obj = Db()
 
+exclude_cli_list = get_exclude_cfg_list()
 
 # Add groups from other modules
 config.add_command(aaa.aaa)
@@ -1090,7 +1091,11 @@ config.add_command(feature.feature)
 config.add_command(kdump.kdump)
 config.add_command(kube.kubernetes)
 config.add_command(muxcable.muxcable)
-config.add_command(nat.nat)
+
+if 'INCLUDE_NAT: n' not in exclude_cli_list:
+    #add nat commands
+    config.add_command(nat.nat)
+
 config.add_command(vlan.vlan)
 config.add_command(vxlan.vxlan)
 

--- a/exclude-cfg/exclude-cfg.yaml
+++ b/exclude-cfg/exclude-cfg.yaml
@@ -1,0 +1,1 @@
+#list of the disabled config options

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     url='https://github.com/Azure/sonic-utilities',
     maintainer='Joe LeVeque',
     maintainer_email='jolevequ@microsoft.com',
+    include_package_data=True,
     packages=[
         'acl_loader',
         'clear',
@@ -60,6 +61,7 @@ setup(
         'utilities_common',
         'watchdogutil',
         'sonic_cli_gen',
+        'exclude-cfg',
     ],
     package_data={
         'generic_config_updater': ['generic_config_updater.conf.json'],

--- a/show/main.py
+++ b/show/main.py
@@ -16,6 +16,7 @@ from utilities_common import util_base
 from utilities_common.db import Db
 import utilities_common.constants as constants
 from utilities_common.general import load_db_config
+from utilities_common.helper import get_exclude_cfg_list
 
 # mock the redis for unit test purposes #
 try:
@@ -154,6 +155,8 @@ def is_gearbox_configured():
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help', '-?'])
 
+exclude_cli_list = get_exclude_cfg_list()
+
 #
 # 'cli' group (root group)
 #
@@ -182,7 +185,11 @@ cli.add_command(interfaces.interfaces)
 cli.add_command(kdump.kdump)
 cli.add_command(kube.kubernetes)
 cli.add_command(muxcable.muxcable)
-cli.add_command(nat.nat)
+
+if 'INCLUDE_NAT: n' not in exclude_cli_list:
+    #add nat commands
+    cli.add_command(nat.nat)
+
 cli.add_command(platform.platform)
 cli.add_command(processes.processes)
 cli.add_command(reboot_cause.reboot_cause)

--- a/utilities_common/helper.py
+++ b/utilities_common/helper.py
@@ -1,3 +1,4 @@
+import os
 from dump.match_infra import MatchEngine, MatchRequest, ConnectionPool
 from dump.match_helper import get_matched_keys
 from .db import Db
@@ -64,3 +65,14 @@ def get_port_pbh_binding(db_wrap, port, ns):
     ret = m_engine.fetch(req)
     pbh_tables, _ = get_matched_keys(ret)
     return pbh_tables
+
+def get_exclude_cfg_list():
+    """ Returns a list with the disabled config options
+        the corresponding CLI should be excluded.
+    """
+    cur_file_path = os.path.dirname(os.path.abspath(__file__))
+    exclude_cli_path = os.path.join(cur_file_path, '../', 'exclude-cfg', 'exclude-cfg.yaml')
+    with open(exclude_cli_path) as exclude_cli_file:
+        exclude_cli_list = [line.rstrip() for line in exclude_cli_file]
+
+    return exclude_cli_list


### PR DESCRIPTION
Added helper function to get a list of the disabled components
Disable NAT commands when INCLUDE_NAT is not set
Moved "clear nat" to separate module - nat.py
Added base infrastructure to get a list of the disabled components
Available CLI commands should be updated according to the given feature set



